### PR TITLE
ci: add renovate config

### DIFF
--- a/.github/workflows/validate-renovate.yaml
+++ b/.github/workflows/validate-renovate.yaml
@@ -1,0 +1,19 @@
+# Caller workflow for the reusable validate-renovate workflow in loft-sh/github-actions.
+name: Validate Renovate Config
+
+on:
+  pull_request:
+    paths:
+      - 'renovate.json'
+      - 'renovate.json5'
+      - '.renovaterc'
+      - '.renovaterc.json'
+
+permissions: {}
+
+jobs:
+  validate-renovate:
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: loft-sh/github-actions/.github/workflows/validate-renovate.yaml@b52efbd927586ea78282073f79d2423e552c9f62 # validate-renovate/v1

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "baseBranchPatterns": ["main"],
+  "labels": ["dependencies"],
+  "prHourlyLimit": 5,
+  "prConcurrentLimit": 10,
+  "minimumReleaseAge": "3 days",
+  "schedule": ["before 6am on monday"],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"]
+  },
+  "packageRules": [
+    {
+      "description": "npm: 7-day stabilization period for all JS deps",
+      "matchManagers": ["npm"],
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "npm: group all non-major updates",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "npm-non-major"
+    },
+    {
+      "description": "npm: major updates individually for human review",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["major"]
+    },
+    {
+      "description": "Group GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    }
+  ]
+}


### PR DESCRIPTION
Closes DEVOPS-971

## Summary

- Onboard Renovate for this public TypeScript/npm library, starting from the loft-sh baseline (`config:recommended` + `:semanticCommits` + digest-pinned GitHub Actions, weekly schedule, security alerts bypass schedule).
- Tailor npm rules per loft-sh conventions: 7-day stabilization for all JS deps, group non-major npm updates, majors individually for human review.
- Add the `validate-renovate` CI caller workflow so future config edits are validated on every PR.

## Coverage

| Surface | Manager |
|---|---|
| `package.json` (4 deps + 2 devDeps, exact-pinned) | built-in `npm` |
| `.github/workflows/validate-renovate.yaml` reusable-workflow ref | built-in `github-actions` (digest-pinned via `helpers:pinGitHubActionDigests`) |

No lockfile exists: the library is consumed as a git dependency (`npm install https://github.com/loft-sh/loft-javascript-client`), so npm manages `package.json` ranges directly.

## Deliberately not managed

- **`gen/` generated TypeScript models** — generated from loft-sh API definitions. These are source files that import nothing versioned and pin no dependency versions, so there is nothing for Renovate to update; no manager and no `ignorePaths` change needed (`config:recommended` already scopes managers via `:ignoreModulesAndTests`).
- **`lib/` build output** — gitignored build artifacts; not a dependency surface.
- No custom regex managers were needed: there are no out-of-band version pins (no Dockerfiles, no `.nvmrc`/`.tool-versions`/`engines`, no `npx @x.y.z` pins, no curl/release-download installs).

## Test plan

- `renovate-config-validator renovate.json` -> passed ("Config validated successfully").
- No custom regex managers, so no matchString verification required.
- `LOG_LEVEL=debug renovate --platform=local --dry-run=extract` -> extracted 2 package files, manager stats `npm: {fileCount: 1, depCount: 6}` and `github-actions: {fileCount: 1, depCount: 1}`, covering every ecosystem in the inventory.
- `actionlint` on the workflow -> 0 findings; `zizmor` -> 0 findings.

## Post-merge checklist

- [ ] Dependency Dashboard issue appears and the first run resolves both managers (npm, github-actions).
- [ ] The existing GitHub security alert on the default branch gets a `security`-labeled Renovate PR.
